### PR TITLE
Use short syntax for React.Fragment

### DIFF
--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -31,7 +31,7 @@ type Props = ConnectedProps<typeof connector>;
 
 const component = (props: Props) => {
   return (
-    <React.Fragment>
+    <>
       {props.hitsIDs.map(([hit, id], i) => {
         const style = {
           color: hit ? yellow[700] : grey[500],
@@ -40,7 +40,7 @@ const component = (props: Props) => {
 
         return <Star key={id} style={style} />;
       })}
-    </React.Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
This commit uses the uniform short-hand syntax for React.Fragment ("<></>").