### PR TITLE
Refactor refocusing into store

### DIFF
--- a/src/__tests__/components/Answer.test.tsx
+++ b/src/__tests__/components/Answer.test.tsx
@@ -3,27 +3,41 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
 
-import { Action, changeAnswer } from "../../actions";
+import { ACK_REFOCUS, changeAnswer } from "../../actions";
 import { Answer } from "../../components/Answer";
 import { bukvarkoApp } from "../../reducers";
 
-it("dispatches the action.", () => {
+it("dispatches ACK_REFOCUS on initialization.", () => {
+  const store = createStore(bukvarkoApp);
+  const mockDispatch = jest.fn();
+  store.dispatch = mockDispatch;
+
+  render(
+    <Provider store={store}>
+      <Answer />
+    </Provider>
+  );
+
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
+  expect(mockDispatch.mock.calls[0][0].type).toEqual(ACK_REFOCUS);
+});
+
+it("dispatches the actions.", () => {
   const store = createStore(bukvarkoApp);
   const mockDispatch = jest.fn();
   store.dispatch = mockDispatch;
 
   const rendered = render(
     <Provider store={store}>
-      <Answer refocusEl={React.createRef<HTMLInputElement>()} />
+      <Answer />
     </Provider>
   );
 
   fireEvent.change(rendered.getByTestId("answer"), {
     target: { value: "some answer" },
   });
-  expect(mockDispatch).toHaveBeenCalledTimes(1);
 
-  const action: Action = mockDispatch.mock.calls[0][0];
-
-  expect(action).toEqual(changeAnswer("some answer"));
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  expect(mockDispatch.mock.calls[0][0].type).toEqual(ACK_REFOCUS);
+  expect(mockDispatch.mock.calls[1][0]).toEqual(changeAnswer("some answer"));
 });

--- a/src/__tests__/components/NextQuestion.test.tsx
+++ b/src/__tests__/components/NextQuestion.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
 
-import { GOTO_NEXT_QUESTION } from "../../actions";
+import { ASK_TO_REFOCUS, GOTO_NEXT_QUESTION } from "../../actions";
 import { NextQuestion } from "../../components/NextQuestion";
 import { bukvarkoApp } from "../../reducers";
 
@@ -14,11 +14,12 @@ it("dispatches the action.", () => {
 
   const rendered = render(
     <Provider store={store}>
-      <NextQuestion refocus={() => void 0} />
+      <NextQuestion />
     </Provider>
   );
 
   fireEvent.click(rendered.getByTestId("nextQuestion"));
-  expect(mockDispatch).toHaveBeenCalledTimes(1);
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(mockDispatch.mock.calls[0][0].type).toBe(GOTO_NEXT_QUESTION);
+  expect(mockDispatch.mock.calls[1][0].type).toBe(ASK_TO_REFOCUS);
 });

--- a/src/__tests__/components/PreviousQuestion.test.tsx
+++ b/src/__tests__/components/PreviousQuestion.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
 
-import { GOTO_PREVIOUS_QUESTION } from "../../actions";
+import { ASK_TO_REFOCUS, GOTO_PREVIOUS_QUESTION } from "../../actions";
 import { PreviousQuestion } from "../../components/PreviousQuestion";
 import { bukvarkoApp } from "../../reducers";
 
@@ -14,11 +14,12 @@ it("dispatches the action.", () => {
 
   const rendered = render(
     <Provider store={store}>
-      <PreviousQuestion refocus={() => void 0} />
+      <PreviousQuestion />
     </Provider>
   );
 
   fireEvent.click(rendered.getByTestId("previousQuestion"));
-  expect(mockDispatch).toHaveBeenCalledTimes(1);
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(mockDispatch.mock.calls[0][0].type).toBe(GOTO_PREVIOUS_QUESTION);
+  expect(mockDispatch.mock.calls[1][0].type).toBe(ASK_TO_REFOCUS);
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -17,7 +17,24 @@ interface GotoNextQuestion {
   type: typeof GOTO_NEXT_QUESTION;
 }
 
-export type Action = ChangeAnswer | GotoPreviousQuestion | GotoNextQuestion;
+export const ASK_TO_REFOCUS = "ASK_TO_REFOCUS";
+
+interface AskToRefocus {
+  type: typeof ASK_TO_REFOCUS;
+}
+
+export const ACK_REFOCUS = "ACK_REFOCUS";
+
+interface AckRefocus {
+  type: typeof ACK_REFOCUS;
+}
+
+export type Action =
+  | ChangeAnswer
+  | GotoPreviousQuestion
+  | GotoNextQuestion
+  | AskToRefocus
+  | AckRefocus;
 
 export function changeAnswer(answer: string): Action {
   return { type: CHANGE_ANSWER, answer: answer };
@@ -29,4 +46,12 @@ export function gotoPreviousQuestion(): Action {
 
 export function gotoNextQuestion(): Action {
   return { type: GOTO_NEXT_QUESTION };
+}
+
+export function askToRefocus(): Action {
+  return { type: ASK_TO_REFOCUS };
+}
+
+export function ackRefocus(): Action {
+  return { type: ACK_REFOCUS };
 }

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -1,17 +1,28 @@
 import { TextField } from "@material-ui/core";
 import * as React from "react";
-import { Ref } from "react";
+import { Ref, useEffect } from "react";
+import { useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { changeAnswer } from "../actions";
+import { ackRefocus, changeAnswer } from "../actions";
 import { State } from "../reducers";
 
-export function Answer(props: { refocusEl: Ref<HTMLInputElement> }) {
+export function Answer() {
   const answer = useSelector(
     (state: State) => state.answers.get(state.currentQuestion) || ""
   );
 
   const dispatch = useDispatch();
+
+  const inputEl: Ref<HTMLInputElement> = useRef(null);
+  const focused = useSelector((state: State) => state.focused);
+
+  useEffect(() => {
+    if (!focused) {
+      inputEl.current?.focus();
+      dispatch(ackRefocus());
+    }
+  });
 
   return (
     <TextField
@@ -26,7 +37,7 @@ export function Answer(props: { refocusEl: Ref<HTMLInputElement> }) {
         },
         "data-testid": "answer",
       }}
-      inputRef={props.refocusEl}
+      inputRef={inputEl}
       onChange={(e) => {
         dispatch(changeAnswer(e.target.value));
       }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,5 @@
 import { Container, Grid, Paper } from "@material-ui/core";
 import * as React from "react";
-import { Ref, useRef } from "react";
 
 import { Answer } from "./Answer";
 import { Judge } from "./Judge";
@@ -11,26 +10,21 @@ import { ScoreBar } from "./ScoreBar";
 import { Speaker } from "./Speaker";
 
 export function App() {
-  const refocusEl: Ref<HTMLInputElement> = useRef(null);
-  const refocus = () => {
-    refocusEl.current?.focus();
-  };
-
   return (
     <Container>
       <Paper elevation={3} style={{ padding: "1em" }}>
         <Grid container>
           <Grid item xs={1}>
-            <PreviousQuestion refocus={refocus} />
+            <PreviousQuestion />
           </Grid>
           <Grid item xs={3}>
             <Question />
           </Grid>
 
           <Grid item xs={7}>
-            <Answer refocusEl={refocusEl} />
+            <Answer />
 
-            <Speaker refocus={refocus} />
+            <Speaker />
 
             <div style={{ marginTop: "1em" }}>
               <Judge />
@@ -42,7 +36,7 @@ export function App() {
           </Grid>
 
           <Grid item xs={1}>
-            <NextQuestion refocus={refocus} />
+            <NextQuestion />
           </Grid>
         </Grid>
       </Paper>

--- a/src/components/NextQuestion.tsx
+++ b/src/components/NextQuestion.tsx
@@ -3,16 +3,16 @@ import ArrowRight from "@material-ui/icons/ArrowRight";
 import * as React from "react";
 import { useDispatch } from "react-redux";
 
-import { gotoNextQuestion } from "../actions";
+import { askToRefocus, gotoNextQuestion } from "../actions";
 
-export function NextQuestion(props: { refocus: () => void }) {
+export function NextQuestion() {
   const dispatch = useDispatch();
 
   return (
     <IconButton
       onClick={() => {
         dispatch(gotoNextQuestion());
-        props.refocus();
+        dispatch(askToRefocus());
       }}
       data-testid="nextQuestion"
     >

--- a/src/components/PreviousQuestion.tsx
+++ b/src/components/PreviousQuestion.tsx
@@ -3,15 +3,15 @@ import ArrowLeft from "@material-ui/icons/ArrowLeft";
 import * as React from "react";
 import { useDispatch } from "react-redux";
 
-import { gotoPreviousQuestion } from "../actions";
+import { askToRefocus, gotoPreviousQuestion } from "../actions";
 
-export function PreviousQuestion(props: { refocus: () => void }) {
+export function PreviousQuestion() {
   const dispatch = useDispatch();
   return (
     <IconButton
       onClick={() => {
         dispatch(gotoPreviousQuestion());
-        props.refocus();
+        dispatch(askToRefocus());
       }}
       data-testid="previousQuestion"
     >

--- a/src/components/Speaker.tsx
+++ b/src/components/Speaker.tsx
@@ -1,8 +1,9 @@
 import { IconButton } from "@material-ui/core";
 import RecordVoiceOver from "@material-ui/icons/RecordVoiceOver";
 import * as React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
+import { askToRefocus } from "../actions";
 import { State } from "../reducers";
 
 function speak(text: string) {
@@ -17,15 +18,17 @@ function speak(text: string) {
   speechSynthesis.speak(u);
 }
 
-export function Speaker(props: { refocus: () => void }) {
+export function Speaker() {
   const text = useSelector((state: State) => {
     const answer = state.answers.get(state.currentQuestion);
     return answer ? `Ovde piše: ${answer}` : "Ovde ništa ne piše.";
   });
 
+  const dispatch = useDispatch();
+
   const onClick = () => {
     speak(text);
-    props.refocus();
+    dispatch(askToRefocus());
   };
 
   return (

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,7 +1,8 @@
-import { enableMapSet } from "immer";
-import { produce } from "immer";
+import { enableMapSet, produce } from "immer";
 
 import {
+  ACK_REFOCUS,
+  ASK_TO_REFOCUS,
   Action,
   CHANGE_ANSWER,
   GOTO_NEXT_QUESTION,
@@ -14,6 +15,7 @@ enableMapSet(); //  See https://immerjs.github.io/immer/docs/installation#pick-y
 export interface State {
   readonly currentQuestion: QuestionID;
   readonly answers: Map<QuestionID, string>;
+  readonly focused: boolean;
 }
 
 function verifyState(state: State) {
@@ -38,6 +40,7 @@ export function initializeState(): State {
   const result = {
     currentQuestion: questionBank.questions[0].id,
     answers: new Map<QuestionID, string>(),
+    focused: false,
   };
 
   verifyState(result);
@@ -62,6 +65,11 @@ export function bukvarkoApp(
       case GOTO_NEXT_QUESTION:
         draft.currentQuestion = questionBank.next(state.currentQuestion);
         break;
+      case ASK_TO_REFOCUS:
+        draft.focused = false;
+        break;
+      case ACK_REFOCUS:
+        draft.focused = true;
     }
   });
 


### PR DESCRIPTION
This commit splits the logic around user focus into the store.  Instead of passing callbacks around, components talk *via* actions (ask to refocus/acknowledge refocus). Consequently, the main input element acts according to the state (refocused or not).