### PR TITLE
Rename focus state to focusPending

### DIFF
--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -15,10 +15,10 @@ export function Answer() {
   const dispatch = useDispatch();
 
   const inputEl: Ref<HTMLInputElement> = useRef(null);
-  const focused = useSelector((state: State) => state.focused);
+  const focusPending = useSelector((state: State) => state.focusPending);
 
   useEffect(() => {
-    if (!focused) {
+    if (focusPending) {
       inputEl.current?.focus();
       dispatch(ackRefocus());
     }

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -15,7 +15,7 @@ enableMapSet(); //  See https://immerjs.github.io/immer/docs/installation#pick-y
 export interface State {
   readonly currentQuestion: QuestionID;
   readonly answers: Map<QuestionID, string>;
-  readonly focused: boolean;
+  readonly focusPending: boolean;
 }
 
 function verifyState(state: State) {
@@ -40,7 +40,7 @@ export function initializeState(): State {
   const result = {
     currentQuestion: questionBank.questions[0].id,
     answers: new Map<QuestionID, string>(),
-    focused: false,
+    focusPending: true,
   };
 
   verifyState(result);
@@ -66,10 +66,10 @@ export function bukvarkoApp(
         draft.currentQuestion = questionBank.next(state.currentQuestion);
         break;
       case ASK_TO_REFOCUS:
-        draft.focused = false;
+        draft.focusPending = true;
         break;
       case ACK_REFOCUS:
-        draft.focused = true;
+        draft.focusPending = false;
     }
   });
 


### PR DESCRIPTION
This commit makes the focus part of the state more precise. Namely, `focus` implies that we always _track_ focus, while `focusPending` hints that we merely requesed a refocusing. Tracking focus of the input element is actually a much harder task and not necessary for the usability (*i.e.*, we also want to allow the user to _blur_ on purpose).