### PR TITLE
Make module imports uniform

### DIFF
--- a/src/__tests__/components/Answer.test.tsx
+++ b/src/__tests__/components/Answer.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import configureMockFactory from "redux-mock-store";
 
-import { ACK_REFOCUS, changeAnswer } from "../../actions";
+import * as action from "../../action";
 import { Answer } from "../../components/Answer";
 
 it("dispatches ACK_REFOCUS when focus pending.", () => {
@@ -22,7 +22,7 @@ it("dispatches ACK_REFOCUS when focus pending.", () => {
   );
 
   expect(mockDispatch).toHaveBeenCalledTimes(1);
-  expect(mockDispatch.mock.calls[0][0].type).toEqual(ACK_REFOCUS);
+  expect(mockDispatch.mock.calls[0][0].type).toEqual(action.ACK_REFOCUS);
 });
 
 it("dispatches the actions.", () => {
@@ -45,6 +45,8 @@ it("dispatches the actions.", () => {
   });
 
   expect(mockDispatch).toHaveBeenCalledTimes(2);
-  expect(mockDispatch.mock.calls[0][0].type).toEqual(ACK_REFOCUS);
-  expect(mockDispatch.mock.calls[1][0]).toEqual(changeAnswer("some answer"));
+  expect(mockDispatch.mock.calls[0][0].type).toEqual(action.ACK_REFOCUS);
+  expect(mockDispatch.mock.calls[1][0]).toEqual(
+    action.changeAnswer("some answer")
+  );
 });

--- a/src/__tests__/components/App.test.tsx
+++ b/src/__tests__/components/App.test.tsx
@@ -3,12 +3,13 @@ import * as React from "react";
 import { Provider } from "react-redux";
 
 import { App } from "../../components/App";
-import { questionBank } from "../../QuestionBank";
+import * as question from "../../question";
 import * as select from "../../select";
 import * as storeFactory from "../../storeFactory";
 
+const deps = { questionBank: question.bank };
+
 function renderApp() {
-  const deps = { questionBank };
   const store = storeFactory.produce(deps);
   const selectWithDeps = new select.WithDeps(deps);
 
@@ -55,7 +56,7 @@ it("handles correct answers without problems.", () => {
   const rendered = renderApp();
 
   fireEvent.change(rendered.getByTestId("answer"), {
-    target: { value: questionBank.questions[0].expectedAnswer },
+    target: { value: deps.questionBank.questions[0].expectedAnswer },
   });
 });
 
@@ -63,6 +64,8 @@ it("handles incorrect answers without problems.", () => {
   const rendered = renderApp();
 
   fireEvent.change(rendered.getByTestId("answer"), {
-    target: { value: "incorrect " + questionBank.questions[0].expectedAnswer },
+    target: {
+      value: "incorrect " + deps.questionBank.questions[0].expectedAnswer,
+    },
   });
 });

--- a/src/__tests__/components/NextQuestion.test.tsx
+++ b/src/__tests__/components/NextQuestion.test.tsx
@@ -4,11 +4,11 @@ import { Provider } from "react-redux";
 import configureMockFactory from "redux-mock-store";
 import thunk from "redux-thunk";
 
-import { ASK_TO_REFOCUS } from "../../actions";
+import * as action from "../../action";
 import { NextQuestion } from "../../components/NextQuestion";
-import * as effects from "../../effects";
+import * as effect from "../../effect";
 
-jest.mock("../../effects");
+jest.mock("../../effect");
 
 it("dispatches the action.", async () => {
   const store = configureMockFactory([thunk])();
@@ -18,7 +18,7 @@ it("dispatches the action.", async () => {
 
   const dummy = { hello: 1 };
 
-  (effects.nextQuestion as any).mockResolvedValue(dummy);
+  (effect.nextQuestion as any).mockResolvedValue(dummy);
 
   const rendered = render(
     <Provider store={store}>
@@ -30,5 +30,5 @@ it("dispatches the action.", async () => {
 
   expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(await mockDispatch.mock.calls[0][0]).toBe(dummy);
-  expect(mockDispatch.mock.calls[1][0].type).toBe(ASK_TO_REFOCUS);
+  expect(mockDispatch.mock.calls[1][0].type).toBe(action.ASK_TO_REFOCUS);
 });

--- a/src/__tests__/components/PreviousQuestion.test.tsx
+++ b/src/__tests__/components/PreviousQuestion.test.tsx
@@ -4,11 +4,11 @@ import { Provider } from "react-redux";
 import configureMockFactory from "redux-mock-store";
 import thunk from "redux-thunk";
 
-import { ASK_TO_REFOCUS } from "../../actions";
+import * as action from "../../action";
 import { PreviousQuestion } from "../../components/PreviousQuestion";
-import * as effects from "../../effects";
+import * as effect from "../../effect";
 
-jest.mock("../../effects");
+jest.mock("../../effect");
 
 it("provokes the state change.", async () => {
   const store = configureMockFactory([thunk])();
@@ -18,7 +18,7 @@ it("provokes the state change.", async () => {
 
   const dummy = { hello: 1 };
 
-  (effects.previousQuestion as any).mockResolvedValue(dummy);
+  (effect.previousQuestion as any).mockResolvedValue(dummy);
 
   const rendered = render(
     <Provider store={store}>
@@ -30,5 +30,5 @@ it("provokes the state change.", async () => {
 
   expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(await mockDispatch.mock.calls[0][0]).toBe(dummy);
-  expect(mockDispatch.mock.calls[1][0].type).toBe(ASK_TO_REFOCUS);
+  expect(mockDispatch.mock.calls[1][0].type).toBe(action.ASK_TO_REFOCUS);
 });

--- a/src/__tests__/reducers.test.ts
+++ b/src/__tests__/reducers.test.ts
@@ -1,31 +1,35 @@
-import * as effects from "../effects";
-import { questionBank } from "../QuestionBank";
+import * as effect from "../effect";
+import * as question from "../question";
 import * as storeFactory from "../storeFactory";
 
-const deps = { questionBank };
+const deps = { questionBank: question.bank };
 
 it("initializes the current question to the first question.", () => {
   const store = storeFactory.produce(deps);
 
-  expect(store.getState().currentQuestion).toBe(questionBank.questions[0].id);
+  expect(store.getState().currentQuestion).toBe(
+    deps.questionBank.questions[0].id
+  );
 });
 
 it("selects the second question on going forward upon initialization.", () => {
   const store = storeFactory.produce(deps);
-  store.dispatch(effects.nextQuestion() as any);
+  store.dispatch(effect.nextQuestion() as any);
 
   if (deps.questionBank.questions.length > 1) {
-    expect(store.getState().currentQuestion).toBe(questionBank.questions[1].id);
+    expect(store.getState().currentQuestion).toBe(
+      deps.questionBank.questions[1].id
+    );
   }
 });
 
 it("selects the last question on going backwards upon initialization.", () => {
   const store = storeFactory.produce(deps);
-  store.dispatch(effects.previousQuestion() as any);
+  store.dispatch(effect.previousQuestion() as any);
 
   if (deps.questionBank.questions.length > 0) {
     expect(store.getState().currentQuestion).toBe(
-      questionBank.questions[questionBank.questions.length - 1].id
+      deps.questionBank.questions[deps.questionBank.questions.length - 1].id
     );
   }
 });

--- a/src/__tests__/select.test.tsx
+++ b/src/__tests__/select.test.tsx
@@ -1,10 +1,10 @@
-import * as effects from "../effects";
-import { QuestionID, questionBank } from "../QuestionBank";
+import * as effect from "../effect";
+import * as question from "../question";
 import * as reducer from "../reducer";
 import * as select from "../select";
 import * as storeFactory from "../storeFactory";
 
-const deps = { questionBank };
+const deps = { questionBank: question.bank };
 
 it("selects no hits on initial state.", () => {
   const state: reducer.State = reducer.initializeState(deps);
@@ -18,7 +18,7 @@ it("selects no hits on initial state.", () => {
 });
 
 it("selects hits on all correct answers.", () => {
-  const answers = new Map<QuestionID, string>();
+  const answers = new Map<question.ID, string>();
   for (const q of deps.questionBank.questions) {
     answers.set(q.id, q.expectedAnswer);
   }
@@ -49,7 +49,7 @@ it("selects first question on initial state.", () => {
 it("selects the second question on next question upon initialization.", () => {
   if (deps.questionBank.questions.length > 1) {
     const store = storeFactory.produce(deps);
-    store.dispatch(effects.nextQuestion() as any);
+    store.dispatch(effect.nextQuestion() as any);
 
     const selectWithDeps = new select.WithDeps(deps);
 
@@ -61,7 +61,7 @@ it("selects the second question on next question upon initialization.", () => {
 
 it("selects the last question on previous question upon initialization.", () => {
   const store = storeFactory.produce(deps);
-  store.dispatch(effects.previousQuestion() as any);
+  store.dispatch(effect.previousQuestion() as any);
 
   const selectWithDeps = new select.WithDeps(deps);
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,4 +1,4 @@
-import { QuestionID } from "./QuestionBank";
+import * as question from "./question";
 
 export const CHANGE_ANSWER = "CHANGE_ANSWER";
 
@@ -10,7 +10,7 @@ interface ChangeAnswer {
 export const GOTO_QUESTION = "GOTO_QUESTION";
 interface GotoQuestion {
   type: typeof GOTO_QUESTION;
-  questionID: QuestionID;
+  questionID: question.ID;
 }
 
 export const ASK_TO_REFOCUS = "ASK_TO_REFOCUS";
@@ -31,7 +31,7 @@ export function changeAnswer(answer: string): Action {
   return { type: CHANGE_ANSWER, answer: answer };
 }
 
-export function gotoQuestion(questionID: QuestionID): Action {
+export function gotoQuestion(questionID: question.ID): Action {
   return { type: GOTO_QUESTION, questionID: questionID };
 }
 

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -4,23 +4,25 @@ import { Ref, useEffect } from "react";
 import { useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { ackRefocus, changeAnswer } from "../actions";
-import { State } from "../reducer";
+import * as action from "../action";
+import * as reducer from "../reducer";
 
 export function Answer() {
   const answer = useSelector(
-    (state: State) => state.answers.get(state.currentQuestion) || ""
+    (state: reducer.State) => state.answers.get(state.currentQuestion) || ""
   );
 
   const dispatch = useDispatch();
 
   const inputEl: Ref<HTMLInputElement> = useRef(null);
-  const focusPending = useSelector((state: State) => state.focusPending);
+  const focusPending = useSelector(
+    (state: reducer.State) => state.focusPending
+  );
 
   useEffect(() => {
     if (focusPending) {
       inputEl.current?.focus();
-      dispatch(ackRefocus());
+      dispatch(action.ackRefocus());
     }
   });
 
@@ -39,7 +41,7 @@ export function Answer() {
       }}
       inputRef={inputEl}
       onChange={(e) => {
-        dispatch(changeAnswer(e.target.value));
+        dispatch(action.changeAnswer(e.target.value));
       }}
       value={answer}
     />

--- a/src/components/Judge.tsx
+++ b/src/components/Judge.tsx
@@ -3,15 +3,15 @@ import ThumbUp from "@material-ui/icons/ThumbUp";
 import * as React from "react";
 import { useSelector } from "react-redux";
 
-import { compareAnswers, questionBank } from "../QuestionBank";
-import { State } from "../reducer";
+import * as question from "../question";
+import * as reducer from "../reducer";
 
 export function Judge() {
-  const hit = useSelector((state: State) => {
-    const question = questionBank.get(state.currentQuestion);
+  const hit = useSelector((state: reducer.State) => {
+    const q = question.bank.get(state.currentQuestion);
     const answer = state.answers.get(state.currentQuestion) || "";
 
-    return compareAnswers(question.expectedAnswer, answer);
+    return question.compareAnswers(q.expectedAnswer, answer);
   });
 
   return hit ? (

--- a/src/components/NextQuestion.tsx
+++ b/src/components/NextQuestion.tsx
@@ -3,8 +3,8 @@ import ArrowRight from "@material-ui/icons/ArrowRight";
 import * as React from "react";
 import { useDispatch } from "react-redux";
 
-import * as actions from "../actions";
-import * as effects from "../effects";
+import * as actions from "../action";
+import * as effect from "../effect";
 
 export function NextQuestion() {
   const dispatch = useDispatch();
@@ -12,7 +12,7 @@ export function NextQuestion() {
   return (
     <IconButton
       onClick={() => {
-        dispatch(effects.nextQuestion());
+        dispatch(effect.nextQuestion());
         dispatch(actions.askToRefocus());
       }}
       data-testid="nextQuestion"

--- a/src/components/PreviousQuestion.tsx
+++ b/src/components/PreviousQuestion.tsx
@@ -3,15 +3,15 @@ import ArrowLeft from "@material-ui/icons/ArrowLeft";
 import * as React from "react";
 import { useDispatch } from "react-redux";
 
-import * as actions from "../actions";
-import * as effects from "../effects";
+import * as actions from "../action";
+import * as effect from "../effect";
 
 export function PreviousQuestion() {
   const dispatch = useDispatch();
   return (
     <IconButton
       onClick={() => {
-        dispatch(effects.previousQuestion());
+        dispatch(effect.previousQuestion());
         dispatch(actions.askToRefocus());
       }}
       data-testid="previousQuestion"

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 
-import { questionBank } from "../QuestionBank";
-import { State } from "../reducer";
+import * as question from "../question";
+import * as reducer from "../reducer";
 
 export function Question() {
   const imageURL = useSelector(
-    (state: State) => questionBank.get(state.currentQuestion).imageURL
+    (state: reducer.State) => question.bank.get(state.currentQuestion).imageURL
   );
 
   return (

--- a/src/components/ScoreBar.tsx
+++ b/src/components/ScoreBar.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { useContext } from "react";
 import { useSelector } from "react-redux";
 
-import { QuestionID } from "../QuestionBank";
+import * as question from "../question";
 import * as reducer from "../reducer";
 import * as select from "../select";
 
@@ -19,7 +19,7 @@ function Indicator(props: { hit: boolean; current: boolean }) {
 }
 
 function Score(props: {
-  hitsIDs: Array<[boolean, QuestionID]>;
+  hitsIDs: Array<[boolean, question.ID]>;
   currentIndex: number;
 }) {
   return (

--- a/src/components/Speaker.tsx
+++ b/src/components/Speaker.tsx
@@ -3,8 +3,8 @@ import RecordVoiceOver from "@material-ui/icons/RecordVoiceOver";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { askToRefocus } from "../actions";
-import { State } from "../reducer";
+import * as action from "../action";
+import * as reducer from "../reducer";
 
 function speak(text: string) {
   const u = new SpeechSynthesisUtterance();
@@ -19,7 +19,7 @@ function speak(text: string) {
 }
 
 export function Speaker() {
-  const text = useSelector((state: State) => {
+  const text = useSelector((state: reducer.State) => {
     const answer = state.answers.get(state.currentQuestion);
     return answer ? `Ovde piše: ${answer}` : "Ovde ništa ne piše.";
   });
@@ -28,7 +28,7 @@ export function Speaker() {
 
   const onClick = () => {
     speak(text);
-    dispatch(askToRefocus());
+    dispatch(action.askToRefocus());
   };
 
   return (

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,8 +1,0 @@
-import { QuestionBank } from "./QuestionBank";
-
-/**
- * Represent a bundle of global dependencies.
- */
-export interface Dependencies {
-  questionBank: QuestionBank;
-}

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -1,0 +1,8 @@
+import * as question from "./question";
+
+/**
+ * Represent a bundle of global dependencies.
+ */
+export interface Register {
+  questionBank: question.Bank;
+}

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,27 +1,27 @@
 import { Dispatch } from "redux";
 
-import { gotoQuestion } from "./actions";
-import { Dependencies } from "./dependencies";
-import { State } from "./reducer";
+import * as action from "./action";
+import * as dependency from "./dependency";
+import * as reducer from "./reducer";
 
 export function nextQuestion() {
   return function (
     dispatch: Dispatch,
-    getState: () => State,
-    deps: Dependencies
+    getState: () => reducer.State,
+    deps: dependency.Register
   ): void {
     const questionID = deps.questionBank.next(getState().currentQuestion);
-    dispatch(gotoQuestion(questionID));
+    dispatch(action.gotoQuestion(questionID));
   };
 }
 
 export function previousQuestion() {
   return function (
     dispatch: Dispatch,
-    getState: () => State,
-    deps: Dependencies
+    getState: () => reducer.State,
+    deps: dependency.Register
   ): void {
     const questionID = deps.questionBank.previous(getState().currentQuestion);
-    dispatch(gotoQuestion(questionID));
+    dispatch(action.gotoQuestion(questionID));
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,11 @@ import { render } from "react-dom";
 import { Provider } from "react-redux";
 
 import { App } from "./components/App";
-import { questionBank } from "./QuestionBank";
+import * as question from "./question";
 import * as select from "./select";
 import * as storeFactory from "./storeFactory";
 
-const deps = { questionBank };
+const deps = { questionBank: question.bank };
 const store = storeFactory.produce(deps);
 const selectWithDeps = new select.WithDeps(deps);
 

--- a/src/question.ts
+++ b/src/question.ts
@@ -1,16 +1,16 @@
-export type QuestionID = string;
+export type ID = string;
 
 export class Question {
   constructor(
-    public id: QuestionID,
+    public id: ID,
     public imageURL: string,
     public expectedAnswer: string
   ) {}
 }
 
-function verifyThatIndicesMatch(qb: QuestionBank) {
-  for (const [i, q] of qb.questions.entries()) {
-    const idx = qb.index(q.id);
+function verifyThatIndicesMatch(bank: Bank) {
+  for (const [i, q] of bank.questions.entries()) {
+    const idx = bank.index(q.id);
     if (i !== idx) {
       throw Error(
         `Unexpected mismatching index() result (== ${idx}) and index in the question (== ${i}`
@@ -19,23 +19,23 @@ function verifyThatIndicesMatch(qb: QuestionBank) {
   }
 }
 
-function verifyThatPreviousLoopsThrough(qb: QuestionBank) {
-  if (qb.questions.length === 0) {
+function verifyThatPreviousLoopsThrough(bank: Bank) {
+  if (bank.questions.length === 0) {
     throw Error("Unexpected empty question bank");
   }
 
-  const loop = new Array<QuestionID>(qb.questions.length + 1);
+  const loop = new Array<ID>(bank.questions.length + 1);
 
-  let cursor: QuestionID = qb.questions[0].id;
-  for (let i = 0; i < qb.questions.length + 1; i++) {
-    const prev = qb.previous(cursor);
+  let cursor: ID = bank.questions[0].id;
+  for (let i = 0; i < bank.questions.length + 1; i++) {
+    const prev = bank.previous(cursor);
     loop[i] = cursor;
     cursor = prev;
   }
 
   const expected = [
-    qb.questions[0].id,
-    ...qb.questions.map((q) => q.id).reverse(),
+    bank.questions[0].id,
+    ...bank.questions.map((q) => q.id).reverse(),
   ];
 
   const passed =
@@ -46,21 +46,21 @@ function verifyThatPreviousLoopsThrough(qb: QuestionBank) {
   }
 }
 
-function verifyThatNextLoopsThrough(qb: QuestionBank) {
-  if (qb.questions.length === 0) {
+function verifyThatNextLoopsThrough(bank: Bank) {
+  if (bank.questions.length === 0) {
     throw Error("Unexpected empty question bank");
   }
 
-  const loop = new Array<QuestionID>(qb.questions.length + 1);
+  const loop = new Array<ID>(bank.questions.length + 1);
 
-  let cursor: QuestionID = qb.questions[0].id;
-  for (let i = 0; i < qb.questions.length + 1; i++) {
-    const next = qb.next(cursor);
+  let cursor: ID = bank.questions[0].id;
+  for (let i = 0; i < bank.questions.length + 1; i++) {
+    const next = bank.next(cursor);
     loop[i] = cursor;
     cursor = next;
   }
 
-  const expected = [...qb.questions.map((q) => q.id), qb.questions[0].id];
+  const expected = [...bank.questions.map((q) => q.id), bank.questions[0].id];
 
   const passed =
     expected.length === loop.length && expected.every((v, i) => loop[i] === v);
@@ -70,9 +70,9 @@ function verifyThatNextLoopsThrough(qb: QuestionBank) {
   }
 }
 
-function verifyAllGet(qb: QuestionBank) {
-  for (const q of qb.questions) {
-    const got = qb.get(q.id).id;
+function verifyAllGet(bank: Bank) {
+  for (const q of bank.questions) {
+    const got = bank.get(q.id).id;
     const passed = got === q.id;
     if (!passed) {
       throw Error(`Expected question ID ${q.id}, but got: ${got}`);
@@ -80,9 +80,9 @@ function verifyAllGet(qb: QuestionBank) {
   }
 }
 
-function verifyHas(qb: QuestionBank) {
-  for (const q of qb.questions) {
-    if (!qb.has(q.id)) {
+function verifyHas(bank: Bank) {
+  for (const q of bank.questions) {
+    if (!bank.has(q.id)) {
       throw Error(
         `Expected ID to be positive in has(), but it was not: ${q.id}`
       );
@@ -90,27 +90,27 @@ function verifyHas(qb: QuestionBank) {
   }
 }
 
-function verifyQuestionBank(qb: QuestionBank) {
-  verifyThatIndicesMatch(qb);
-  verifyThatPreviousLoopsThrough(qb);
-  verifyThatNextLoopsThrough(qb);
-  verifyAllGet(qb);
-  verifyHas(qb);
+function verifyQuestionBank(bank: Bank) {
+  verifyThatIndicesMatch(bank);
+  verifyThatPreviousLoopsThrough(bank);
+  verifyThatNextLoopsThrough(bank);
+  verifyAllGet(bank);
+  verifyHas(bank);
 }
 
-export class QuestionBank {
-  private questionIndex: Map<QuestionID, number>;
-  private questionMap: Map<QuestionID, Question>;
-  private previousMap: Map<QuestionID, QuestionID>;
-  private nextMap: Map<QuestionID, QuestionID>;
+export class Bank {
+  private questionIndex: Map<ID, number>;
+  private questionMap: Map<ID, Question>;
+  private previousMap: Map<ID, ID>;
+  private nextMap: Map<ID, ID>;
 
   constructor(public questions: Array<Question>) {
-    this.questionIndex = new Map<QuestionID, number>();
+    this.questionIndex = new Map<ID, number>();
     for (const [i, q] of questions.entries()) {
       this.questionIndex.set(q.id, i);
     }
 
-    this.questionMap = new Map<QuestionID, Question>();
+    this.questionMap = new Map<ID, Question>();
     for (const q of questions) {
       if (this.questionMap.has(q.id)) {
         throw Error(`Duplicate ID in questions: ${q.id}`);
@@ -118,7 +118,7 @@ export class QuestionBank {
       this.questionMap.set(q.id, q);
     }
 
-    this.previousMap = new Map<QuestionID, QuestionID>();
+    this.previousMap = new Map<ID, ID>();
     if (questions.length > 0) {
       this.previousMap.set(questions[0].id, questions[questions.length - 1].id);
 
@@ -127,7 +127,7 @@ export class QuestionBank {
       }
     }
 
-    this.nextMap = new Map<QuestionID, QuestionID>();
+    this.nextMap = new Map<ID, ID>();
     if (questions.length > 0) {
       this.nextMap.set(questions[questions.length - 1].id, questions[0].id);
 
@@ -139,7 +139,7 @@ export class QuestionBank {
     verifyQuestionBank(this);
   }
 
-  public index(id: QuestionID): number {
+  public index(id: ID): number {
     const result = this.questionIndex.get(id);
     if (result === undefined) {
       throw Error(`Question ID is invalid: ${id}`);
@@ -148,7 +148,7 @@ export class QuestionBank {
     return result;
   }
 
-  public next(id: QuestionID): QuestionID {
+  public next(id: ID): ID {
     const result = this.nextMap.get(id);
     if (result === undefined) {
       throw Error(`Question ID is invalid: ${id}`);
@@ -157,7 +157,7 @@ export class QuestionBank {
     return result;
   }
 
-  public previous(id: QuestionID): QuestionID {
+  public previous(id: ID): ID {
     const result = this.previousMap.get(id);
     if (result === undefined) {
       throw Error(`Question ID is invalid: ${id}`);
@@ -166,11 +166,11 @@ export class QuestionBank {
     return result;
   }
 
-  public has(id: QuestionID): boolean {
+  public has(id: ID): boolean {
     return this.questionMap.has(id);
   }
 
-  public get(id: QuestionID): Question {
+  public get(id: ID): Question {
     const result = this.questionMap.get(id);
     if (result === undefined) {
       throw Error(`Question ID is invalid: ${id}`);
@@ -180,7 +180,7 @@ export class QuestionBank {
   }
 }
 
-export const questionBank = new QuestionBank([
+export const bank = new Bank([
   {
     id: "slon",
     imageURL: "./media/slon.jpeg",

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,47 +1,41 @@
 import { enableMapSet, produce } from "immer";
 
-import {
-  ACK_REFOCUS,
-  ASK_TO_REFOCUS,
-  Action,
-  CHANGE_ANSWER,
-  GOTO_QUESTION,
-} from "./actions";
-import { Dependencies } from "./dependencies";
-import { QuestionID } from "./QuestionBank";
+import * as action from "./action";
+import * as dependency from "./dependency";
+import * as question from "./question";
 
 enableMapSet(); //  See https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 
 export interface State {
-  readonly currentQuestion: QuestionID;
-  readonly answers: Map<QuestionID, string>;
+  readonly currentQuestion: question.ID;
+  readonly answers: Map<question.ID, string>;
   readonly focusPending: boolean;
 }
 
-export function initializeState(deps: Dependencies) {
+export function initializeState(deps: dependency.Register) {
   return {
     currentQuestion: deps.questionBank.questions[0].id,
-    answers: new Map<QuestionID, string>(),
+    answers: new Map<question.ID, string>(),
     focusPending: true,
   };
 }
 
-export function create(deps: Dependencies) {
+export function create(deps: dependency.Register) {
   const initialState = initializeState(deps);
 
-  const reducer = (state: State = initialState, action: Action): State => {
+  const reducer = (state: State = initialState, a: action.Action): State => {
     const result = produce(state, (draft) => {
-      switch (action.type) {
-        case CHANGE_ANSWER:
-          draft.answers.set(state.currentQuestion, action.answer);
+      switch (a.type) {
+        case action.CHANGE_ANSWER:
+          draft.answers.set(state.currentQuestion, a.answer);
           break;
-        case GOTO_QUESTION:
-          draft.currentQuestion = action.questionID;
+        case action.GOTO_QUESTION:
+          draft.currentQuestion = a.questionID;
           break;
-        case ASK_TO_REFOCUS:
+        case action.ASK_TO_REFOCUS:
           draft.focusPending = true;
           break;
-        case ACK_REFOCUS:
+        case action.ACK_REFOCUS:
           draft.focusPending = false;
       }
     });

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,24 +1,24 @@
 import deepEqual from "deep-equal";
 import * as React from "react";
 
-import { Dependencies } from "./dependencies";
-import { QuestionID, compareAnswers } from "./QuestionBank";
-import { State } from "./reducer";
+import * as dependency from "./dependency";
+import * as question from "./question";
+import * as reducer from "./reducer";
 
 export class WithDeps {
-  constructor(private deps: Dependencies) {}
+  constructor(private deps: dependency.Register) {}
 
-  public hitsIDs(state: State): Array<[boolean, QuestionID]> {
-    const result = new Array<[boolean, QuestionID]>(
+  public hitsIDs(state: reducer.State): Array<[boolean, question.ID]> {
+    const result = new Array<[boolean, question.ID]>(
       this.deps.questionBank.questions.length
     );
 
-    for (const [i, question] of this.deps.questionBank.questions.entries()) {
-      const answer = state.answers.get(question.id) || "";
+    for (const [i, q] of this.deps.questionBank.questions.entries()) {
+      const answer = state.answers.get(q.id) || "";
 
-      const hit = compareAnswers(question.expectedAnswer, answer);
+      const hit = question.compareAnswers(q.expectedAnswer, answer);
 
-      result[i] = [hit, question.id];
+      result[i] = [hit, q.id];
     }
 
     // Post-conditions
@@ -37,7 +37,7 @@ export class WithDeps {
     return result;
   }
 
-  public currentIndex(state: State): number {
+  public currentIndex(state: reducer.State): number {
     return this.deps.questionBank.index(state.currentQuestion);
   }
 }

--- a/src/stateInvariants.ts
+++ b/src/stateInvariants.ts
@@ -1,12 +1,12 @@
 import { Action, Dispatch, Middleware, MiddlewareAPI } from "redux";
 
-import { QuestionBank } from "./QuestionBank";
-import { State } from "./reducer";
+import * as question from "./question";
+import * as reducer from "./reducer";
 
-export function create(questionBank: QuestionBank) {
-  const middleware: Middleware = (api: MiddlewareAPI<Dispatch, State>) => (
-    next: Dispatch
-  ) => (action: Action) => {
+export function create(questionBank: question.Bank) {
+  const middleware: Middleware = (
+    api: MiddlewareAPI<Dispatch, reducer.State>
+  ) => (next: Dispatch) => (action: Action) => {
     // Verify before dispatching
     verify(api.getState(), questionBank);
 
@@ -21,7 +21,7 @@ export function create(questionBank: QuestionBank) {
   return middleware;
 }
 
-function verify(state: State, questionBank: QuestionBank) {
+function verify(state: reducer.State, questionBank: question.Bank) {
   if (!questionBank.has(state.currentQuestion)) {
     throw Error(
       `Current question is not in the question bank: ${state.currentQuestion}`

--- a/src/storeFactory.ts
+++ b/src/storeFactory.ts
@@ -1,16 +1,15 @@
 import { applyMiddleware, createStore } from "redux";
 import thunk from "redux-thunk";
 
-import { Dependencies } from "./dependencies";
-import { questionBank } from "./QuestionBank";
+import * as dependency from "./dependency";
 import * as reducer from "./reducer";
 import * as stateInvariants from "./stateInvariants";
 
-export function produce(deps: Dependencies) {
+export function produce(deps: dependency.Register) {
   return createStore(
     reducer.create(deps),
     applyMiddleware(
-      stateInvariants.create(questionBank),
+      stateInvariants.create(deps.questionBank),
       thunk.withExtraArgument(deps)
     )
   );


### PR DESCRIPTION
This commit makes uniform the naming and importing of all the logic modules (*i.e.* non-components). This results in shorter class names and identifiers which are easier to trace.