### PR TITLE
Fix omitted selectors with dependencies

### DIFF
--- a/src/components/Judge.tsx
+++ b/src/components/Judge.tsx
@@ -1,18 +1,21 @@
 import ThumbDown from "@material-ui/icons/ThumbDown";
 import ThumbUp from "@material-ui/icons/ThumbUp";
 import * as React from "react";
+import { useContext } from "react";
 import { useSelector } from "react-redux";
 
-import * as question from "../question";
 import * as reducer from "../reducer";
+import * as select from "../select";
 
 export function Judge() {
-  const hit = useSelector((state: reducer.State) => {
-    const q = question.bank.get(state.currentQuestion);
-    const answer = state.answers.get(state.currentQuestion) || "";
+  const selectContext = useContext(select.Context);
+  if (selectContext === undefined) {
+    throw Error("Expected selector context to be set.");
+  }
 
-    return question.compareAnswers(q.expectedAnswer, answer);
-  });
+  const hit = useSelector((s: reducer.State) =>
+    selectContext.currentAnswerHits(s)
+  );
 
   return hit ? (
     <ThumbUp style={{ color: "green" }} />

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,12 +1,18 @@
 import * as React from "react";
+import { useContext } from "react";
 import { useSelector } from "react-redux";
 
-import * as question from "../question";
 import * as reducer from "../reducer";
+import * as select from "../select";
 
 export function Question() {
-  const imageURL = useSelector(
-    (state: reducer.State) => question.bank.get(state.currentQuestion).imageURL
+  const selectContext = useContext(select.Context);
+  if (selectContext === undefined) {
+    throw Error("Expected selector context to be set.");
+  }
+
+  const imageURL = useSelector((s: reducer.State) =>
+    selectContext.currentQuestionImageURL(s)
   );
 
   return (

--- a/src/select.ts
+++ b/src/select.ts
@@ -8,6 +8,17 @@ import * as reducer from "./reducer";
 export class WithDeps {
   constructor(private deps: dependency.Register) {}
 
+  public currentQuestionImageURL(state: reducer.State): string {
+    return this.deps.questionBank.get(state.currentQuestion).imageURL;
+  }
+
+  public currentAnswerHits(state: reducer.State): boolean {
+    const q = this.deps.questionBank.get(state.currentQuestion);
+    const answer = state.answers.get(state.currentQuestion) || "";
+
+    return question.compareAnswers(q.expectedAnswer, answer);
+  }
+
   public hitsIDs(state: reducer.State): Array<[boolean, question.ID]> {
     const result = new Array<[boolean, question.ID]>(
       this.deps.questionBank.questions.length


### PR DESCRIPTION
This commit refactors selectors with global dependencies into `select` module. These selectors were omitted mistakenly in the commit 6214dbb2dba508b39e8d1e8e1abef75c9d5e7b93.