### PR TITLE
Move speech to effects

### DIFF
--- a/src/__tests__/components/App.test.tsx
+++ b/src/__tests__/components/App.test.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import { Provider } from "react-redux";
 
 import { App } from "../../components/App";
-import * as question from "../../question";
 import * as select from "../../select";
 import * as storeFactory from "../../storeFactory";
+import * as mockDependency from "../mockDependency";
 
-const deps = { questionBank: question.bank };
+const deps = mockDependency.register;
 
 function renderApp() {
   const store = storeFactory.produce(deps);

--- a/src/__tests__/components/Speaker.test.tsx
+++ b/src/__tests__/components/Speaker.test.tsx
@@ -5,7 +5,7 @@ import configureMockFactory from "redux-mock-store";
 import thunk from "redux-thunk";
 
 import * as action from "../../action";
-import { NextQuestion } from "../../components/NextQuestion";
+import { Speaker } from "../../components/Speaker";
 import * as effect from "../../effect";
 
 jest.mock("../../effect");
@@ -18,15 +18,15 @@ it("dispatches the actions and effects.", async () => {
 
   const dummy = { hello: 1 };
 
-  (effect.nextQuestion as any).mockResolvedValue(dummy);
+  (effect.speak as any).mockResolvedValue(dummy);
 
   const rendered = render(
     <Provider store={store}>
-      <NextQuestion />
+      <Speaker />
     </Provider>
   );
 
-  fireEvent.click(rendered.getByTestId("nextQuestion"));
+  fireEvent.click(rendered.getByTestId("speak"));
 
   expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(await mockDispatch.mock.calls[0][0]).toBe(dummy);

--- a/src/__tests__/mockDependency.ts
+++ b/src/__tests__/mockDependency.ts
@@ -1,0 +1,12 @@
+import * as dependency from "../dependency";
+import * as question from "../question";
+
+const mockSpeechSynthesis: unknown = {
+  cancel: () => {},
+  speak: (_: SpeechSynthesisUtterance) => {},
+};
+
+export const register: dependency.Register = {
+  questionBank: question.bank,
+  speechSynthesis: mockSpeechSynthesis as SpeechSynthesis,
+};

--- a/src/__tests__/reducers.test.ts
+++ b/src/__tests__/reducers.test.ts
@@ -1,8 +1,8 @@
 import * as effect from "../effect";
-import * as question from "../question";
 import * as storeFactory from "../storeFactory";
+import * as mockDependency from "./mockDependency";
 
-const deps = { questionBank: question.bank };
+const deps = mockDependency.register;
 
 it("initializes the current question to the first question.", () => {
   const store = storeFactory.produce(deps);

--- a/src/__tests__/select.test.tsx
+++ b/src/__tests__/select.test.tsx
@@ -3,8 +3,9 @@ import * as question from "../question";
 import * as reducer from "../reducer";
 import * as select from "../select";
 import * as storeFactory from "../storeFactory";
+import * as mockDependency from "./mockDependency";
 
-const deps = { questionBank: question.bank };
+const deps = mockDependency.register;
 
 it("selects no hits on initial state.", () => {
   const state: reducer.State = reducer.initializeState(deps);

--- a/src/components/Speaker.tsx
+++ b/src/components/Speaker.tsx
@@ -1,38 +1,25 @@
 import { IconButton } from "@material-ui/core";
 import RecordVoiceOver from "@material-ui/icons/RecordVoiceOver";
 import * as React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import * as action from "../action";
-import * as reducer from "../reducer";
-
-function speak(text: string) {
-  const u = new SpeechSynthesisUtterance();
-  u.text = text;
-  u.lang = "sr-RS";
-  u.volume = 1; // 0 to 1
-  u.rate = 0.7; // 0.1 to 1
-  u.pitch = 2; //0 to 2
-
-  speechSynthesis.cancel();
-  speechSynthesis.speak(u);
-}
+import * as effect from "../effect";
 
 export function Speaker() {
-  const text = useSelector((state: reducer.State) => {
-    const answer = state.answers.get(state.currentQuestion);
-    return answer ? `Ovde piše: ${answer}` : "Ovde ništa ne piše.";
-  });
-
   const dispatch = useDispatch();
 
   const onClick = () => {
-    speak(text);
+    dispatch(effect.speak());
     dispatch(action.askToRefocus());
   };
 
   return (
-    <IconButton style={{ marginLeft: "1em" }} onClick={onClick}>
+    <IconButton
+      style={{ marginLeft: "1em" }}
+      onClick={onClick}
+      data-testid="speak"
+    >
       <RecordVoiceOver />
     </IconButton>
   );

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -5,4 +5,5 @@ import * as question from "./question";
  */
 export interface Register {
   questionBank: question.Bank;
+  speechSynthesis: SpeechSynthesis;
 }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -25,3 +25,25 @@ export function previousQuestion() {
     dispatch(action.gotoQuestion(questionID));
   };
 }
+
+export function speak() {
+  return function (
+    _: Dispatch,
+    getState: () => reducer.State,
+    deps: dependency.Register
+  ): void {
+    const answer = getState().answers.get(getState().currentQuestion);
+
+    const text = answer === "" ? `Ovde piše: ${answer}` : "Ovde ništa ne piše.";
+
+    const u = new SpeechSynthesisUtterance();
+    u.text = text;
+    u.lang = "sr-RS";
+    u.volume = 1; // 0 to 1
+    u.rate = 0.7; // 0.1 to 1
+    u.pitch = 2; //0 to 2
+
+    deps.speechSynthesis.cancel();
+    deps.speechSynthesis.speak(u);
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,12 +5,18 @@ import { render } from "react-dom";
 import { Provider } from "react-redux";
 
 import { App } from "./components/App";
+import * as dependency from "./dependency";
 import * as question from "./question";
 import * as select from "./select";
 import * as storeFactory from "./storeFactory";
 
-const deps = { questionBank: question.bank };
+const deps: dependency.Register = {
+  questionBank: question.bank,
+  speechSynthesis: speechSynthesis,
+};
+
 const store = storeFactory.produce(deps);
+
 const selectWithDeps = new select.WithDeps(deps);
 
 render(


### PR DESCRIPTION
This commit refactors speech functionality out of the `Speaker` component into a separate effect. This introduces dependency injection for `speechSynthesis` thus allowing us to test the features related to speech.