### PR TITLE
Add uniform question image hight

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -15,11 +15,16 @@ export function Question() {
     selectContext.currentQuestionImageURL(s)
   );
 
+  // This value is computed manually over all the images.
+  const maxImageHeight = 234;
+
   return (
-    <img
-      src={imageURL}
-      alt="question image"
-      style={{ width: "90%", border: "1px solid black" }}
-    />
+    <div style={{ height: maxImageHeight }}>
+      <img
+        src={imageURL}
+        alt="question image"
+        style={{ width: "90%", border: "1px solid black" }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
The question images come in different heights. This commit assigns an uniform height to the container `div` of images.