### PR TITLE
Remove obsolete fullscreen part of the state

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -87,17 +87,6 @@ export function deleteAll(): Action {
   return { type: DELETE_ALL };
 }
 
-export const TOGGLE_FULLSCREEN = "TOGGLE_FULLSCREEN";
-
-interface ToggleFullscreen {
-  type: typeof TOGGLE_FULLSCREEN;
-  value: boolean;
-}
-
-export function toggleFullscreen(value: boolean): Action {
-  return { type: TOGGLE_FULLSCREEN, value };
-}
-
 export type Action =
   | ChangeAnswer
   | GotoQuestion
@@ -106,5 +95,4 @@ export type Action =
   | TogglePreferences
   | ChangeTranslation
   | ChangeVoice
-  | DeleteAll
-  | ToggleFullscreen;
+  | DeleteAll;

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -19,7 +19,6 @@ export interface State {
   readonly answers: Map<question.ID, string>;
   readonly focusPending: boolean;
   readonly preferencesVisible: boolean;
-  readonly fullscreen: boolean;
 }
 
 export function initializeState(deps: dependency.Registry): State {
@@ -56,7 +55,6 @@ export function initializeState(deps: dependency.Registry): State {
     answers: new Map<question.ID, string>(),
     focusPending: true,
     preferencesVisible: true,
-    fullscreen: false,
   };
 }
 
@@ -95,8 +93,6 @@ export function create(deps: dependency.Registry) {
         case action.DELETE_ALL:
           draft.answers.clear();
           break;
-        case action.TOGGLE_FULLSCREEN:
-          draft.fullscreen = a.value;
       }
     });
 


### PR DESCRIPTION
Fullscreen was implemented as a separate component with the component's state. Since no other component depends on it, there is no need to pollute the application state with it.