### PR TITLE
Rename module `reducer` to `app`

### DIFF
--- a/src/__tests__/autosave.test.ts
+++ b/src/__tests__/autosave.test.ts
@@ -1,6 +1,6 @@
 import * as action from "../action";
+import * as app from "../app";
 import * as i18n from "../i18n";
-import * as reducer from "../reducer";
 import * as speech from "../speech";
 import * as storeFactory from "../storeFactory";
 import * as mockDependency from "./mockDependency";
@@ -10,7 +10,7 @@ it("does not patch anything from an initial state on empty storage.", () => {
   const store = storeFactory.produce(deps);
 
   // Load
-  const state = reducer.initializeState(deps);
+  const state = app.initializeState(deps);
 
   // Loaded state should equal the state in the memory.
   expect(state).toEqual(store.getState());
@@ -24,7 +24,7 @@ it("stores the language, voice and lastVoiceByLanguage on language change.", () 
   store.dispatch(action.changeTranslation(i18n.SERBIAN));
 
   // Load
-  const state = reducer.initializeState(deps);
+  const state = app.initializeState(deps);
 
   // Loaded state should equal the state in the memory.
   expect(state).toEqual(store.getState());
@@ -38,7 +38,7 @@ it("stores the new voice and the last voice on voice change.", () => {
   store.dispatch(action.changeVoice(new speech.VoiceID("en-US", "Barbara")));
 
   // Load
-  const state = reducer.initializeState(deps);
+  const state = app.initializeState(deps);
 
   // Loaded state should equal the state in the memory.
   expect(state).toEqual(store.getState());

--- a/src/__tests__/select.test.tsx
+++ b/src/__tests__/select.test.tsx
@@ -1,13 +1,13 @@
+import * as app from "../app";
 import * as effect from "../effect";
 import * as question from "../question";
-import * as reducer from "../reducer";
 import * as select from "../select";
 import * as storeFactory from "../storeFactory";
 import * as mockDependency from "./mockDependency";
 
 it("selects no hits on initial state.", () => {
   const deps = mockDependency.initializeRegistry();
-  const state: reducer.State = reducer.initializeState(deps);
+  const state: app.State = app.initializeState(deps);
 
   const selectWithDeps = new select.WithDeps(deps);
 
@@ -22,8 +22,8 @@ it("selects hits on all correct answers.", () => {
   const answers = new Map<question.ID, string>();
   const selectWithDeps = new select.WithDeps(deps);
 
-  const state: reducer.State = {
-    ...reducer.initializeState(deps),
+  const state: app.State = {
+    ...app.initializeState(deps),
     answers,
   };
 
@@ -41,7 +41,7 @@ it("selects hits on all correct answers.", () => {
 
 it("selects first question on initial state.", () => {
   const deps = mockDependency.initializeRegistry();
-  const state: reducer.State = reducer.initializeState(deps);
+  const state: app.State = app.initializeState(deps);
 
   const selectWithDeps = new select.WithDeps(deps);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -63,7 +63,7 @@ export function initializeState(deps: dependency.Registry): State {
   return state;
 }
 
-export function create(deps: dependency.Registry) {
+export function createReducer(deps: dependency.Registry) {
   const initialState = initializeState(deps);
 
   const reducer = (state: State = initialState, a: action.Action): State => {

--- a/src/autosave.ts
+++ b/src/autosave.ts
@@ -2,10 +2,10 @@ import { produce } from "immer";
 import { Dispatch, Middleware, MiddlewareAPI } from "redux";
 
 import * as action from "./action";
+import * as app from "./app";
 import * as dependency from "./dependency";
 import * as i18n from "./i18n";
 import * as question from "./question";
-import * as reducer from "./reducer";
 import * as speech from "./speech";
 import * as stateInvariants from "./stateInvariants";
 
@@ -14,8 +14,8 @@ import * as stateInvariants from "./stateInvariants";
  */
 export function patchState(
   deps: dependency.Registry,
-  state: reducer.State
-): reducer.State {
+  state: app.State
+): app.State {
   // Precondition
   stateInvariants.verify(state, deps);
 
@@ -100,9 +100,9 @@ export function patchState(
 }
 
 export function create(deps: dependency.Registry) {
-  const middleware: Middleware = (
-    api: MiddlewareAPI<Dispatch, reducer.State>
-  ) => (next: Dispatch) => (a: action.Action) => {
+  const middleware: Middleware = (api: MiddlewareAPI<Dispatch, app.State>) => (
+    next: Dispatch
+  ) => (a: action.Action) => {
     const result = next(a);
 
     switch (a.type) {

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -5,20 +5,18 @@ import { useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import * as action from "../action";
+import * as app from "../app";
 import * as effect from "../effect";
-import * as reducer from "../reducer";
 
 export function Answer() {
   const answer = useSelector(
-    (state: reducer.State) => state.answers.get(state.currentQuestion) || ""
+    (state: app.State) => state.answers.get(state.currentQuestion) || ""
   );
 
   const dispatch = useDispatch();
 
   const inputEl: Ref<HTMLInputElement> = useRef(null);
-  const focusPending = useSelector(
-    (state: reducer.State) => state.focusPending
-  );
+  const focusPending = useSelector((state: app.State) => state.focusPending);
 
   useEffect(() => {
     if (focusPending) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import { Container, Grid, Paper } from "@material-ui/core";
 import * as React from "react";
 import { useSelector } from "react-redux";
 
-import * as reducer from "../reducer";
+import * as app from "../app";
 import { Answer } from "./Answer";
 import { DeleteAll } from "./DeleteAll";
 import { FullScreen } from "./FullScreen";
@@ -16,7 +16,7 @@ import { ScoreBar } from "./ScoreBar";
 import { Speaker } from "./Speaker";
 
 export function App() {
-  const hasVoice = useSelector((s: reducer.State) => s.voice !== undefined);
+  const hasVoice = useSelector((s: app.State) => s.voice !== undefined);
 
   return (
     <Container>

--- a/src/components/Judge.tsx
+++ b/src/components/Judge.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useContext } from "react";
 import { useSelector } from "react-redux";
 
-import * as reducer from "../reducer";
+import * as app from "../app";
 import * as select from "../select";
 
 export function Judge() {
@@ -13,9 +13,7 @@ export function Judge() {
     throw Error("Expected selector context to be set.");
   }
 
-  const hit = useSelector((s: reducer.State) =>
-    selectContext.currentAnswerHits(s)
-  );
+  const hit = useSelector((s: app.State) => selectContext.currentAnswerHits(s));
 
   return hit ? (
     <ThumbUp style={{ color: "green" }} />

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -8,8 +8,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 
 import * as action from "../action";
+import * as app from "../app";
 import * as i18n from "../i18n";
-import * as reducer from "../reducer";
 import * as select from "../select";
 import * as speech from "../speech";
 
@@ -118,7 +118,7 @@ export function Preferences() {
   }
 
   const preferencesVisible = useSelector(
-    (s: reducer.State) => s.preferencesVisible
+    (s: app.State) => s.preferencesVisible
   );
 
   const dispatch = useDispatch();
@@ -126,14 +126,14 @@ export function Preferences() {
   const langs: i18n.LanguageID[] = [...i18nContext.keys()].sort();
 
   const currentTranslation: i18n.LanguageID = useSelector(
-    (s: reducer.State) => s.language
+    (s: app.State) => s.language
   );
   const translation = i18nContext.get(currentTranslation)!;
 
-  const availableVoices = useSelector((s: reducer.State) =>
+  const availableVoices = useSelector((s: app.State) =>
     selectContext.availableVoices(s)
   );
-  const currentVoice = useSelector((s: reducer.State) => s.voice);
+  const currentVoice = useSelector((s: app.State) => s.voice);
 
   return (
     <Drawer

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useContext } from "react";
 import { useSelector } from "react-redux";
 
-import * as reducer from "../reducer";
+import * as app from "../app";
 import * as select from "../select";
 
 export function Question() {
@@ -11,7 +11,7 @@ export function Question() {
     throw Error("Expected selector context to be set.");
   }
 
-  const imageURL = useSelector((s: reducer.State) =>
+  const imageURL = useSelector((s: app.State) =>
     selectContext.currentQuestionImageURL(s)
   );
 

--- a/src/components/ScoreBar.tsx
+++ b/src/components/ScoreBar.tsx
@@ -5,8 +5,8 @@ import * as React from "react";
 import { useContext } from "react";
 import { useSelector } from "react-redux";
 
+import * as app from "../app";
 import * as question from "../question";
-import * as reducer from "../reducer";
 import * as select from "../select";
 
 function Indicator(props: { hit: boolean; current: boolean }) {
@@ -39,8 +39,8 @@ export function ScoreBar() {
     throw Error("Expected selector context to be set.");
   }
 
-  const hitsIDs = useSelector((s: reducer.State) => selectContext.hitsIDs(s));
-  const currentIndex = useSelector((s: reducer.State) =>
+  const hitsIDs = useSelector((s: app.State) => selectContext.hitsIDs(s));
+  const currentIndex = useSelector((s: app.State) =>
     selectContext.currentIndex(s)
   );
 

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,13 +1,13 @@
 import { Dispatch } from "redux";
 
 import * as action from "./action";
+import * as app from "./app";
 import * as dependency from "./dependency";
-import * as reducer from "./reducer";
 
 export function nextQuestion() {
   return function (
     dispatch: Dispatch,
-    getState: () => reducer.State,
+    getState: () => app.State,
     deps: dependency.Registry
   ): void {
     const questionID = deps.questionBank.next(getState().currentQuestion);
@@ -18,7 +18,7 @@ export function nextQuestion() {
 export function previousQuestion() {
   return function (
     dispatch: Dispatch,
-    getState: () => reducer.State,
+    getState: () => app.State,
     deps: dependency.Registry
   ): void {
     const questionID = deps.questionBank.previous(getState().currentQuestion);
@@ -29,7 +29,7 @@ export function previousQuestion() {
 export function speak() {
   return function (
     _: Dispatch,
-    getState: () => reducer.State,
+    getState: () => app.State,
     deps: dependency.Registry
   ): void {
     const voice = getState().voice;

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,20 +1,20 @@
 import deepEqual from "deep-equal";
 import * as React from "react";
 
+import * as app from "./app";
 import * as dependency from "./dependency";
 import * as i18n from "./i18n";
 import * as question from "./question";
-import * as reducer from "./reducer";
 import * as speech from "./speech";
 
 export class WithDeps {
   constructor(private deps: dependency.Registry) {}
 
-  public currentQuestionImageURL(state: reducer.State): string {
+  public currentQuestionImageURL(state: app.State): string {
     return this.deps.questionBank.get(state.currentQuestion).imageURL;
   }
 
-  public resolveTranslation(state: reducer.State): i18n.Translation {
+  public resolveTranslation(state: app.State): i18n.Translation {
     const translation = this.deps.translations.get(state.language);
     if (translation === undefined) {
       throw Error(
@@ -24,7 +24,7 @@ export class WithDeps {
     return translation;
   }
 
-  public currentAnswerHits(state: reducer.State): boolean {
+  public currentAnswerHits(state: app.State): boolean {
     const answer = state.answers.get(state.currentQuestion) || "";
 
     const expectedAnswer = this.resolveTranslation(state).expectedAnswers[
@@ -34,7 +34,7 @@ export class WithDeps {
     return question.compareAnswers(expectedAnswer, answer);
   }
 
-  public hitsIDs(state: reducer.State): Array<[boolean, question.ID]> {
+  public hitsIDs(state: app.State): Array<[boolean, question.ID]> {
     const result = new Array<[boolean, question.ID]>(
       this.deps.questionBank.questions.length
     );
@@ -67,11 +67,11 @@ export class WithDeps {
     return result;
   }
 
-  public currentIndex(state: reducer.State): number {
+  public currentIndex(state: app.State): number {
     return this.deps.questionBank.index(state.currentQuestion);
   }
 
-  public availableVoices(state: reducer.State): Array<speech.VoiceID> {
+  public availableVoices(state: app.State): Array<speech.VoiceID> {
     const r = this.deps.voicesByLanguage.get(state.language);
     if (r === undefined) {
       throw Error(

--- a/src/stateInvariants.ts
+++ b/src/stateInvariants.ts
@@ -1,12 +1,12 @@
 import { Action, Dispatch, Middleware, MiddlewareAPI } from "redux";
 
+import * as app from "./app";
 import * as dependency from "./dependency";
-import * as reducer from "./reducer";
 
 export function create(deps: dependency.Registry) {
-  const middleware: Middleware = (
-    api: MiddlewareAPI<Dispatch, reducer.State>
-  ) => (next: Dispatch) => (action: Action) => {
+  const middleware: Middleware = (api: MiddlewareAPI<Dispatch, app.State>) => (
+    next: Dispatch
+  ) => (action: Action) => {
     // Verify before dispatching
     verify(api.getState(), deps);
 
@@ -21,7 +21,7 @@ export function create(deps: dependency.Registry) {
   return middleware;
 }
 
-export function verify(state: reducer.State, deps: dependency.Registry) {
+export function verify(state: app.State, deps: dependency.Registry) {
   if (!deps.translations.has(state.language)) {
     throw Error(
       `Language in the state is not contained in the translations: ${JSON.stringify(

--- a/src/storeFactory.ts
+++ b/src/storeFactory.ts
@@ -1,14 +1,14 @@
 import { applyMiddleware, createStore } from "redux";
 import thunk from "redux-thunk";
 
+import * as app from "./app";
 import * as autosave from "./autosave";
 import * as dependency from "./dependency";
-import * as reducer from "./reducer";
 import * as stateInvariants from "./stateInvariants";
 
 export function produce(deps: dependency.Registry) {
   return createStore(
-    reducer.create(deps),
+    app.createReducer(deps),
     applyMiddleware(
       stateInvariants.create(deps),
       autosave.create(deps),


### PR DESCRIPTION
The module `reducer` was a misnomer since the application state is also one of its concerns. Hence, "app" summarizes it well: reducer + state.