### PR TITLE
Infer translation language from the browser

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,0 +1,19 @@
+import * as i18n from "../i18n";
+
+it("selects the first language when no language matches.", () => {
+  const lang = i18n.inferDefault("en-GB", ["hr", "sr"]);
+
+  expect(lang).toBe("hr");
+});
+
+it("selects the exact match if available.", () => {
+  const lang = i18n.inferDefault("en", ["hr", "en", "sr"]);
+
+  expect(lang).toBe("en");
+});
+
+it("selects the primary language match if available.", () => {
+  const lang = i18n.inferDefault("en-GB", ["hr", "en", "sr"]);
+
+  expect(lang).toBe("en");
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,8 +31,10 @@ export function initializeState(deps: dependency.Registry): State {
     throw Error("Unexpected empty translations.");
   }
 
-  const langs: i18n.LanguageID[] = [...deps.translations.keys()].sort();
-  const language = langs[0];
+  const language = i18n.inferDefault(
+    navigator.language || "",
+    [...deps.translations.keys()].sort()
+  );
 
   const lastVoiceByLanguage = new Map<
     i18n.LanguageID,

--- a/src/bcp47.ts
+++ b/src/bcp47.ts
@@ -1,8 +1,10 @@
-export function primaryLanguage(spec: string): string {
-  const parts = spec.split("-");
+export type Tag = string;
+
+export function primaryLanguage(tag: string): string {
+  const parts = tag.split("-");
   if (parts.length === 0) {
     throw Error(
-      `Unexpected language specification according to BCP 47: ${spec}`
+      `Unexpected language specification according to BCP 47: ${tag}`
     );
   }
   return parts[0];

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import * as bcp47 from "./bcp47";
 import * as question from "./question";
 
 export type ExpectedAnswers = {
@@ -82,6 +83,39 @@ export function initializeTranslations(): Translations {
   // Post-condition
   if (result.size === 0) {
     throw Error("Expected a non-empty map of translations.");
+  }
+  return result;
+}
+
+/**
+ * Infer the translation language from the navigator language.
+ *
+ * It matches first exactly, then by the primary language. If no match has been found, the first language
+ * in the given list is returned.
+ *
+ * @param navigatorLanguage language as indicated by the browser
+ * @param languages list of available translation languages
+ */
+export function inferDefault(
+  navigatorLanguage: bcp47.Tag,
+  languages: LanguageID[]
+): LanguageID {
+  let result: LanguageID | undefined = undefined;
+
+  for (const lang of languages) {
+    if (lang === navigatorLanguage) {
+      result = lang;
+      break;
+    }
+
+    if (bcp47.primaryLanguage(navigatorLanguage) === lang) {
+      result = lang;
+      break;
+    }
+  }
+
+  if (result === undefined) {
+    return languages[0];
   }
   return result;
 }

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -1,11 +1,10 @@
 import * as bcp47 from "./bcp47";
 import * as i18n from "./i18n";
 
-type LanguageBCP47 = string;
 type VoiceName = string;
 
 export class VoiceID {
-  constructor(public lang: LanguageBCP47, public name: VoiceName) {
+  constructor(public lang: bcp47.Tag, public name: VoiceName) {
     if (lang.includes("/")) {
       throw Error(`Unexpected "/" in the language of the voice: ${lang}`);
     }
@@ -31,10 +30,7 @@ export function voiceIDFromKey(key: string): VoiceID {
 }
 
 export class Voices {
-  private byBCP47 = new Map<
-    LanguageBCP47,
-    Map<VoiceName, SpeechSynthesisVoice>
-  >();
+  private byBCP47 = new Map<bcp47.Tag, Map<VoiceName, SpeechSynthesisVoice>>();
 
   constructor(listOfVoices: Array<SpeechSynthesisVoice>) {
     for (const v of listOfVoices) {
@@ -93,7 +89,7 @@ export class Voices {
     return voice;
   }
 
-  public filterByExactLanguage(lang: LanguageBCP47): Array<VoiceID> {
+  public filterByExactLanguage(lang: bcp47.Tag): Array<VoiceID> {
     const result = new Array<VoiceID>();
 
     const byName = this.byBCP47.get(lang);


### PR DESCRIPTION
Before this commit, the default language was just picked as first in the list of available translations. With this commit the default language is first inferred from the browser first.