### PR TITLE
Fix loading from empty storage

### DIFF
--- a/src/__tests__/mockDependency.ts
+++ b/src/__tests__/mockDependency.ts
@@ -31,6 +31,10 @@ export class MockStorage {
   public clear() {
     this.map.clear();
   }
+
+  get length(): number {
+    return this.map.size;
+  }
 }
 
 export function initializeRegistry(): dependency.Registry {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import deepEqual from "deep-equal";
 import { enableMapSet, produce } from "immer";
 
 import * as action from "./action";
@@ -50,7 +51,7 @@ export function initializeState(deps: dependency.Registry): State {
 
   const voice = lastVoiceByLanguage.get(language);
 
-  let state = {
+  const defaultState = {
     language,
     voice,
     lastVoiceByLanguage,
@@ -60,7 +61,14 @@ export function initializeState(deps: dependency.Registry): State {
     preferencesVisible: true,
   };
 
-  state = autosave.patchState(deps, state);
+  const state = autosave.patchState(deps, defaultState);
+
+  if (deps.storage.length === 0 && !deepEqual(defaultState, state)) {
+    throw Error(
+      "The default state and the state patched by the storage are not equal, " +
+        "but there was nothing in the storage."
+    );
+  }
 
   return state;
 }

--- a/src/autosave.ts
+++ b/src/autosave.ts
@@ -85,11 +85,9 @@ export function patchState(
 
     const maybePreferencesVisible = deps.storage.getItem("preferencesVisible");
     if (
-      maybePreferencesVisible === null ||
-      maybePreferencesVisible === undefined
+      maybePreferencesVisible !== null &&
+      maybePreferencesVisible !== undefined
     ) {
-      draft.preferencesVisible = false;
-    } else {
       draft.preferencesVisible = maybePreferencesVisible === "true";
     }
   });


### PR DESCRIPTION
The autosave changed mistakenly the `preferencesVisible` to false, even though the storage was empty. This commit fixes that particular error.

Additionally, an assertion is added to check that the default state and the state patched from local storage should be equal if the storage is empty.