### PR TITLE
Fix persistence of "delete all" action

### DIFF
--- a/src/autosave.ts
+++ b/src/autosave.ts
@@ -158,6 +158,13 @@ export function create(deps: dependency.Registry) {
         break;
       }
 
+      case action.DELETE_ALL: {
+        for (const question of deps.questionBank.questions) {
+          deps.storage.removeItem(`answer/${question.id}`);
+        }
+        break;
+      }
+
       case action.GOTO_QUESTION: {
         const currentQuestion = api.getState().currentQuestion;
         deps.storage.setItem("currentQuestion", currentQuestion);


### PR DESCRIPTION
Before this commit, the results of the "delete all" action were not persisted since the action was ignored in the autosave middleware.