### PR TITLE
Fix dependency initialization as promise

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Unfortunately } from './Unfortunately';
+
+export class ErrorBoundary extends React.Component<{}, { error: Error | undefined }> {
+  constructor(props: any) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error: error };
+  }
+
+  render() {
+    if (this.state.error !== undefined) {
+      return <Unfortunately error={this.state.error.toString()} />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/Unfortunately.tsx
+++ b/src/components/Unfortunately.tsx
@@ -1,0 +1,17 @@
+import Container from '@material-ui/core/Container';
+import Paper from '@material-ui/core/Paper';
+import SentimentVeryDissatisfiedIcon from '@material-ui/icons/SentimentVeryDissatisfied';
+import * as React from 'react';
+
+export function Unfortunately(props: { error: string }) {
+  return (
+    <Container>
+      <Paper elevation={3} style={{ marginTop: '2em', padding: '2em' }}>
+        <div style={{ textAlign: 'center' }}>
+          <SentimentVeryDissatisfiedIcon />
+        </div>
+        <div style={{ marginTop: '2em' }}>{props.error}</div>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -9,7 +9,7 @@ import * as speech from './speech';
  */
 export interface Registry {
   questionBank: question.Bank;
-  speechSynthesis: SpeechSynthesis;
+  aSpeechSynthesis: SpeechSynthesis;
   translations: i18n.Translations;
   voices: speech.Voices;
   voicesByLanguage: speech.VoicesByLanguage;
@@ -19,19 +19,19 @@ export interface Registry {
 
 export function initializeRegistry(
   questionBank: question.Bank,
-  speechSynthesis: SpeechSynthesis,
+  aSpeechSynthesis: SpeechSynthesis,
   translations: i18n.Translations,
   storage: Storage,
   history: History<LocationState>,
 ): Registry {
-  const voices = new speech.Voices(speechSynthesis.getVoices());
+  const voices = new speech.Voices(aSpeechSynthesis.getVoices());
 
   const voicesByLanguage = speech.groupVoicesByLanguage(voices, translations.keys());
 
   return {
     questionBank,
     translations,
-    speechSynthesis,
+    aSpeechSynthesis: aSpeechSynthesis,
     voices,
     voicesByLanguage,
     storage,

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -43,7 +43,7 @@ export function speak() {
     u.rate = 0.7; // 0.1 to 1
     u.pitch = 2; //0 to 2
 
-    deps.speechSynthesis.cancel();
-    deps.speechSynthesis.speak(u);
+    deps.aSpeechSynthesis.cancel();
+    deps.aSpeechSynthesis.speak(u);
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,36 +1,101 @@
 import 'typeface-roboto';
 
+import { LinearProgress } from '@material-ui/core';
 import { createBrowserHistory } from 'history';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
+import { Store } from 'redux';
 
 import { App } from './components/App';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { Unfortunately } from './components/Unfortunately';
 import * as dependency from './dependency';
 import * as i18n from './i18n';
 import * as question from './question';
 import * as select from './select';
 import * as storeFactory from './storeFactory';
 
-const deps: dependency.Registry = dependency.initializeRegistry(
-  question.initializeBank(),
-  speechSynthesis,
-  i18n.initializeTranslations(),
-  localStorage,
-  createBrowserHistory(),
-);
+interface Ingredients {
+  deps: dependency.Registry;
+  store: Store;
+  selectWithDeps: select.WithDeps;
+}
 
-const store = storeFactory.produce(deps);
+function promiseIngredients(): Promise<Ingredients> {
+  // Remark (Marko Ristin, 2020-04-18): Since the voices might change *while* the application is running,
+  // voices should be integrated in the application state. This is left to a future version as it is hardly
+  // a real issue at the moment.
 
-const selectWithDeps = new select.WithDeps(deps);
+  return new Promise((resolve, _) => {
+    // This is necessary since Chrome needs to load the voices, while other browsers just return the getVoices.
+    if ((window as any).chrome) {
+      speechSynthesis.onvoiceschanged = () => {
+        console.info('voiceschanged event fired.');
+        resolve();
+      };
+    } else {
+      // Wait for half a second. Firefox seemed to have problems loading the voices.
+      setTimeout(() => {
+        resolve();
+      }, 500);
+    }
+  }).then(() => {
+    const deps = dependency.initializeRegistry(
+      question.initializeBank(),
+      speechSynthesis,
+      i18n.initializeTranslations(),
+      localStorage,
+      createBrowserHistory(),
+    );
+
+    const store = storeFactory.produce(deps);
+
+    const selectWithDeps = new select.WithDeps(deps);
+
+    console.info('All we need has been initialized.');
+
+    return { deps, store, selectWithDeps };
+  });
+}
+
+function Main() {
+  const [ingredients, setIngredients] = useState<Ingredients | undefined>(undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (ingredients === undefined && error === undefined) {
+      promiseIngredients()
+        .then((youNeed) => setIngredients(youNeed))
+        .catch((e: Error) => {
+          setError(e.toString());
+        });
+    }
+  });
+
+  if (error !== undefined) {
+    return <Unfortunately error={error} />;
+  } else {
+    if (ingredients !== undefined) {
+      return (
+        <Provider store={ingredients.store}>
+          <select.Context.Provider value={ingredients.selectWithDeps}>
+            <i18n.Context.Provider value={ingredients.deps.translations}>
+              <App />
+            </i18n.Context.Provider>
+          </select.Context.Provider>
+        </Provider>
+      );
+    } else {
+      return <LinearProgress />;
+    }
+  }
+}
 
 render(
-  <Provider store={store}>
-    <select.Context.Provider value={selectWithDeps}>
-      <i18n.Context.Provider value={deps.translations}>
-        <App />
-      </i18n.Context.Provider>
-    </select.Context.Provider>
-  </Provider>,
+  <ErrorBoundary>
+    <Main />
+  </ErrorBoundary>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
It takes a while for the browser to initialize speech synthesis.
Therefore, `speechSynthesis.getVoices()` returned unexpectedly sometimes
an empty array.

This commit fixes the problem by refactoring the initialization of the
dependencies into a promise and showing the progress bar during the
initialization.

Additionally, the commit introduces an error boundary to display any
errors which might occur.