### PR TITLE
Encapsulate answer checking into functions

### DIFF
--- a/src/__tests__/components/App.test.tsx
+++ b/src/__tests__/components/App.test.tsx
@@ -58,7 +58,7 @@ it('handles the correct answer without problems.', () => {
   const { rendered, store, selectWithDeps } = setupAndRenderApp();
 
   const translation = selectWithDeps.resolveTranslation(store.getState());
-  const expectedAnswer = translation.expectedAnswers[store.getState().currentQuestion];
+  const expectedAnswer = translation.answerCheckers[store.getState().currentQuestion];
 
   fireEvent.change(rendered.getByTestId('answer'), {
     target: { value: expectedAnswer },
@@ -69,7 +69,7 @@ it('handles an incorrect answer without problems.', () => {
   const { rendered, store, selectWithDeps } = setupAndRenderApp();
 
   const translation = selectWithDeps.resolveTranslation(store.getState());
-  const expectedAnswer = translation.expectedAnswers[store.getState().currentQuestion];
+  const expectedAnswer = translation.answerCheckers[store.getState().currentQuestion];
 
   fireEvent.change(rendered.getByTestId('answer'), {
     target: {

--- a/src/__tests__/select.test.tsx
+++ b/src/__tests__/select.test.tsx
@@ -1,6 +1,5 @@
 import * as app from '../app';
 import * as effect from '../effect';
-import * as question from '../question';
 import * as select from '../select';
 import * as storeFactory from '../storeFactory';
 import * as mockDependency from './mockDependency';
@@ -19,19 +18,18 @@ it('selects no hits on initial state.', () => {
 
 it('selects hits on all correct answers.', () => {
   const deps = mockDependency.initializeRegistry();
-  const answers = new Map<question.ID, string>();
+  // Mock the translation to always return that the answer is a correct one.
+  for (const translation of deps.translations.values()) {
+    for (const q of deps.questionBank.questions) {
+      (translation.answerCheckers as any)[q.id] = () => true;
+    }
+  }
+
   const selectWithDeps = new select.WithDeps(deps);
 
   const state: app.State = {
     ...app.initializeState(deps),
-    answers,
   };
-
-  const translation = selectWithDeps.resolveTranslation(state);
-
-  for (const q of deps.questionBank.questions) {
-    answers.set(q.id, translation.expectedAnswers[q.id]);
-  }
 
   const hitsAndIDs = selectWithDeps.hitsIDs(state);
   const hits = hitsAndIDs.map(([hit, _]) => hit);

--- a/src/expectAnswer.ts
+++ b/src/expectAnswer.ts
@@ -1,0 +1,14 @@
+export function ignoreCase(...expected: string[]): (answer: string) => boolean {
+  return (answer: string) => {
+    let result = false;
+
+    for (const anExpected of expected) {
+      if (answer.toLowerCase() === anExpected.toLowerCase()) {
+        result = true;
+        break;
+      }
+    }
+
+    return result;
+  };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,8 +9,8 @@ import { croatian } from './i18n/hr';
 import { serbian } from './i18n/sr';
 import * as question from './question';
 
-export type ExpectedAnswers = {
-  readonly [_ in question.ID]: string;
+export type AnswerCheckers = {
+  readonly [_ in question.ID]: (answer: string) => boolean;
 };
 
 export interface Translation {
@@ -18,7 +18,7 @@ export interface Translation {
   languageName: string;
   chooseYourVoice: string;
   noVoiceAvailable: string;
-  expectedAnswers: ExpectedAnswers;
+  answerCheckers: AnswerCheckers;
   hereItSays: string;
   nothingIsWrittenHere: string;
   questionImageAlt: string;

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const german: Translation = {
@@ -5,11 +6,11 @@ export const german: Translation = {
   languageName: 'Deutsch',
   chooseYourVoice: 'Stimme',
   noVoiceAvailable: 'Das System unterstützt keine Stimme für diese Sprache.',
-  expectedAnswers: {
-    elephant: 'Elephant',
-    tiger: 'Tiger',
-    lion: 'Löwe',
-    dog: 'Hund',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('Elephant'),
+    tiger: expectAnswer.ignoreCase('Tiger'),
+    lion: expectAnswer.ignoreCase('Löwe'),
+    dog: expectAnswer.ignoreCase('Hund'),
   },
   hereItSays: 'Hier steht',
   nothingIsWrittenHere: 'Hier steht nichts.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const english: Translation = {
@@ -5,11 +6,11 @@ export const english: Translation = {
   languageName: 'English',
   chooseYourVoice: 'Voice',
   noVoiceAvailable: 'Your system does not provide a voice for this language.',
-  expectedAnswers: {
-    elephant: 'elephant',
-    tiger: 'tiger',
-    lion: 'lion',
-    dog: 'dog',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('elephant'),
+    tiger: expectAnswer.ignoreCase('tiger'),
+    lion: expectAnswer.ignoreCase('lion'),
+    dog: expectAnswer.ignoreCase('dog'),
   },
   hereItSays: 'Here it says',
   nothingIsWrittenHere: 'Nothing has been written.',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const spanish: Translation = {
@@ -5,11 +6,11 @@ export const spanish: Translation = {
   languageName: 'Castellano',
   chooseYourVoice: 'Voz',
   noVoiceAvailable: 'El sistema no soporta la narración en el idioma escogido.',
-  expectedAnswers: {
-    elephant: 'elefante',
-    tiger: 'tigre',
-    lion: 'leon',
-    dog: 'perro',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('elefante'),
+    tiger: expectAnswer.ignoreCase('tigre'),
+    lion: expectAnswer.ignoreCase('leon'),
+    dog: expectAnswer.ignoreCase('perro'),
   },
   hereItSays: 'Aca dice',
   nothingIsWrittenHere: 'Aca no dice nada.',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const french: Translation = {
@@ -5,11 +6,11 @@ export const french: Translation = {
   languageName: 'Francais',
   chooseYourVoice: 'Voix',
   noVoiceAvailable: 'Le logiciel ne fournit pas aucune voix pour cette langue.',
-  expectedAnswers: {
-    elephant: 'éléphant',
-    tiger: 'tigre',
-    lion: 'lion',
-    dog: 'chien',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('éléphant'),
+    tiger: expectAnswer.ignoreCase('tigre'),
+    lion: expectAnswer.ignoreCase('lion'),
+    dog: expectAnswer.ignoreCase('chien'),
   },
   hereItSays: 'Ça dit ici',
   nothingIsWrittenHere: 'Ça ne dit rien ici.',

--- a/src/i18n/hr.ts
+++ b/src/i18n/hr.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const croatian: Translation = {
@@ -5,11 +6,11 @@ export const croatian: Translation = {
   languageName: 'Hrvatski',
   chooseYourVoice: 'Glas',
   noVoiceAvailable: 'Sustav ne podržava glas za ovaj jezik.',
-  expectedAnswers: {
-    elephant: 'slon',
-    tiger: 'tigar',
-    lion: 'lav',
-    dog: 'pas',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('slon'),
+    tiger: expectAnswer.ignoreCase('tigar'),
+    lion: expectAnswer.ignoreCase('lav'),
+    dog: expectAnswer.ignoreCase('pas'),
   },
   hereItSays: 'Ovdje piše',
   nothingIsWrittenHere: 'Ovdje ništa ne piše.',

--- a/src/i18n/sr.ts
+++ b/src/i18n/sr.ts
@@ -1,3 +1,4 @@
+import * as expectAnswer from '../expectAnswer';
 import { Translation } from '../i18n';
 
 export const serbian: Translation = {
@@ -5,11 +6,11 @@ export const serbian: Translation = {
   languageName: 'Srpski',
   chooseYourVoice: 'Glas',
   noVoiceAvailable: 'Sistem ne podržava glas za ovaj jezik.',
-  expectedAnswers: {
-    elephant: 'slon',
-    tiger: 'tigar',
-    lion: 'lav',
-    dog: 'pas',
+  answerCheckers: {
+    elephant: expectAnswer.ignoreCase('slon', 'слон'),
+    tiger: expectAnswer.ignoreCase('tigar', 'тигар'),
+    lion: expectAnswer.ignoreCase('lav', 'лав'),
+    dog: expectAnswer.ignoreCase('pas', 'пас'),
   },
   hereItSays: 'Ovde piše',
   nothingIsWrittenHere: 'Ovde ništa ne piše.',

--- a/src/question.ts
+++ b/src/question.ts
@@ -192,7 +192,3 @@ export function initializeBank(): Bank {
     },
   ]);
 }
-
-export function compareAnswers(expected: string, got: string): boolean {
-  return expected.toLowerCase() === got.toLowerCase();
-}

--- a/src/select.ts
+++ b/src/select.ts
@@ -25,9 +25,9 @@ export class WithDeps {
   public currentAnswerHits(state: app.State): boolean {
     const answer = state.answers.get(state.currentQuestion) || '';
 
-    const expectedAnswer = this.resolveTranslation(state).expectedAnswers[state.currentQuestion];
+    const answerChecker = this.resolveTranslation(state).answerCheckers[state.currentQuestion];
 
-    return question.compareAnswers(expectedAnswer, answer);
+    return answerChecker(answer);
   }
 
   public hitsIDs(state: app.State): Array<[boolean, question.ID]> {
@@ -36,9 +36,9 @@ export class WithDeps {
     for (const [i, q] of this.deps.questionBank.questions.entries()) {
       const answer = state.answers.get(q.id) || '';
 
-      const expectedAnswer = this.resolveTranslation(state).expectedAnswers[q.id];
+      const answerChecker = this.resolveTranslation(state).answerCheckers[q.id];
 
-      const hit = question.compareAnswers(expectedAnswer, answer);
+      const hit = answerChecker(answer);
 
       result[i] = [hit, q.id];
     }


### PR DESCRIPTION
This commit encapsulates answer checking into individual functions so that multiple answers can be accepted (*e.g.*, when different scripts are used such as latin and cyrillic in Serbian).