### PR TITLE
Fix voices detection on Android

### DIFF
--- a/src/__tests__/bcp47.test.ts
+++ b/src/__tests__/bcp47.test.ts
@@ -24,3 +24,8 @@ it('parses correctly the primary language with a region and a script.', () => {
   const lang = bcp47.primaryLanguage('zh-Hant-HK');
   expect(lang).toBe('zh');
 });
+
+it('parses also the primary language with an underscore (important on android!).', () => {
+  const lang = bcp47.primaryLanguage('en_US');
+  expect(lang).toBe('en');
+});

--- a/src/bcp47.ts
+++ b/src/bcp47.ts
@@ -1,7 +1,7 @@
 export type Tag = string;
 
 export function primaryLanguage(tag: string): string {
-  const parts = tag.split('-');
+  const parts = tag.split(/[_-]/);
   if (parts.length === 0) {
     throw Error(`Unexpected language specification according to BCP 47: ${tag}`);
   }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -38,6 +38,7 @@ export function speak() {
 
     const u = new SpeechSynthesisUtterance();
     u.voice = deps.voices.get(voice);
+    u.lang = voice.lang;
     u.text = text;
     u.volume = 1; // 0 to 1
     u.rate = 0.7; // 0.1 to 1


### PR DESCRIPTION
This commit makes a loop that checks repeatedly for `speechSynthesis.getVoices()` and rejects after certain number of retries. This seems to be the best approach for the browsers running on Android.

BCP 47 language tags use underscore (`_`) instead of dash (`-`) on Android, so this had to be fixed. The `lang` property also had to be set on `SpeechSynthesisUtterance` in order to effectuate the language change.