### PR TITLE
Check answers after trimming

### DIFF
--- a/src/expectAnswer.ts
+++ b/src/expectAnswer.ts
@@ -3,7 +3,7 @@ export function ignoreCase(...expected: string[]): (answer: string) => boolean {
     let result = false;
 
     for (const anExpected of expected) {
-      if (answer.toLowerCase() === anExpected.toLowerCase()) {
+      if (answer.toLowerCase().trim() === anExpected.toLowerCase().trim()) {
         result = true;
         break;
       }


### PR DESCRIPTION
This commit improves the answer checkers to check answers after trimming so that occacional spaces and tabs in the answers are ignored.